### PR TITLE
WIP: Exploring possible fixes for #2

### DIFF
--- a/libs/git.d.ts
+++ b/libs/git.d.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Uri, SourceControlInputBox, Event, CancellationToken } from 'vscode';
+import { Uri, Event, Disposable, ProviderResult } from 'vscode';
+export { ProviderResult } from 'vscode';
 
 export interface Git {
 	readonly path: string;
@@ -41,7 +42,10 @@ export interface Commit {
 	readonly hash: string;
 	readonly message: string;
 	readonly parents: string[];
-	readonly authorEmail?: string | undefined;
+	readonly authorDate?: Date;
+	readonly authorName?: string;
+	readonly authorEmail?: string;
+	readonly commitDate?: Date;
 }
 
 export interface Submodule {
@@ -117,6 +121,20 @@ export interface RepositoryUIState {
 export interface LogOptions {
 	/** Max number of log entries to retrieve. If not specified, the default is 32. */
 	readonly maxEntries?: number;
+	readonly path?: string;
+}
+
+export interface CommitOptions {
+	all?: boolean | 'tracked';
+	amend?: boolean;
+	signoff?: boolean;
+	signCommit?: boolean;
+	empty?: boolean;
+}
+
+export interface BranchQuery {
+	readonly remote?: boolean;
+	readonly contains?: string;
 }
 
 export interface Repository {
@@ -158,6 +176,7 @@ export interface Repository {
 	createBranch(name: string, checkout: boolean, ref?: string): Promise<void>;
 	deleteBranch(name: string, force?: boolean): Promise<void>;
 	getBranch(name: string): Promise<Branch>;
+	getBranches(query: BranchQuery): Promise<Ref[]>;
 	setBranchUpstream(name: string, upstream: string): Promise<void>;
 
 	getMergeBase(ref1: string, ref2: string): Promise<string>;
@@ -167,6 +186,7 @@ export interface Repository {
 
 	addRemote(name: string, url: string): Promise<void>;
 	removeRemote(name: string): Promise<void>;
+	renameRemote(name: string, newName: string): Promise<void>;
 
 	fetch(remote?: string, ref?: string, depth?: number): Promise<void>;
 	pull(unshallow?: boolean): Promise<void>;
@@ -174,6 +194,31 @@ export interface Repository {
 
 	blame(path: string): Promise<string>;
 	log(options?: LogOptions): Promise<Commit[]>;
+
+	commit(message: string, opts?: CommitOptions): Promise<void>;
+}
+
+export interface RemoteSource {
+	readonly name: string;
+	readonly description?: string;
+	readonly url: string | string[];
+}
+
+export interface RemoteSourceProvider {
+	readonly name: string;
+	readonly icon?: string; // codicon name
+	readonly supportsQuery?: boolean;
+	getRemoteSources(query?: string): ProviderResult<RemoteSource[]>;
+	publishRepository?(repository: Repository): Promise<void>;
+}
+
+export interface Credentials {
+	readonly username: string;
+	readonly password: string;
+}
+
+export interface CredentialsProvider {
+	getCredentials(host: Uri): ProviderResult<Credentials>;
 }
 
 export type APIState = 'uninitialized' | 'initialized';
@@ -185,6 +230,13 @@ export interface API {
 	readonly repositories: Repository[];
 	readonly onDidOpenRepository: Event<Repository>;
 	readonly onDidCloseRepository: Event<Repository>;
+
+	toGitUri(uri: Uri, ref: string): Uri;
+	getRepository(uri: Uri): Repository | null;
+	init(root: Uri): Promise<Repository | null>;
+
+	registerRemoteSourceProvider(provider: RemoteSourceProvider): Disposable;
+	registerCredentialsProvider(provider: CredentialsProvider): Disposable;
 }
 
 export interface GitExtension {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "am-i-behind",
-	"version": "0.0.1",
+	"version": "1.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/RepoWatcher.ts
+++ b/src/RepoWatcher.ts
@@ -1,4 +1,3 @@
-import * as vscode from 'vscode';
 import { Repository, RepositoryState } from '../libs/git';
 import { log } from './log';
 import { showNotification } from './show-notification';
@@ -50,7 +49,6 @@ export class RepositoryWatcher {
 
     onStateChange(state: RepositoryState) {
         const head = state.HEAD;
-        log(`There were changes for ${this.repository.rootUri}`);
 
         if (head !== undefined) {
             const behind = head.behind;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,14 +5,23 @@ import { RepositoryWatcher } from './RepoWatcher';
 import { waitForGitExtension } from './git';
 import { API } from '../libs/git'
 import { log } from './log';
+import { extractRepositoryName } from './utils';
 
 function onGitExtensionEnabled(git: API) {
 	log(`${git.repositories.length} repos found!`);
+	
+	git.onDidOpenRepository(repo => {
+		log(`Opened ${extractRepositoryName(repo.rootUri)}...`);
+	})
+
+	git.onDidCloseRepository(repo => {
+		log(`Closed ${extractRepositoryName(repo.rootUri)}...`);
+	})
 
 	const repos: RepositoryWatcher[] = [];
 
 	git.repositories.forEach(repository => {
-		log(`setup listener for ${repository.rootUri}...`);
+		log(`setup listener for ${extractRepositoryName(repository.rootUri)}...`);
 
 		// TODO: somehow dispose the watchers
 		repos.push(new RepositoryWatcher(repository));
@@ -24,7 +33,7 @@ function onGitExtensionEnabled(git: API) {
 export function activate(context: vscode.ExtensionContext) {
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "am-i-behind" is now active!');
+	log('Activated!');
 
 	waitForGitExtension().then(gitExtension => {
 		if (gitExtension.enabled) {
@@ -35,7 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
 			if (enabled) {
 				onGitExtensionEnabled(gitExtension.getAPI(1))
 			}
-		});		
+		});
 	});
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,21 @@
 import * as vscode from 'vscode';
 import { RepositoryWatcher } from './RepoWatcher';
 import { waitForGitExtension } from './git';
+import { API } from '../libs/git'
 import { log } from './log';
+
+function onGitExtensionEnabled(git: API) {
+	log(`${git.repositories.length} repos found!`);
+
+	const repos: RepositoryWatcher[] = [];
+
+	git.repositories.forEach(repository => {
+		log(`setup listener for ${repository.rootUri}...`);
+
+		// TODO: somehow dispose the watchers
+		repos.push(new RepositoryWatcher(repository));
+	});
+}
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -12,17 +26,16 @@ export function activate(context: vscode.ExtensionContext) {
 	// This line of code will only be executed once when your extension is activated
 	console.log('Congratulations, your extension "am-i-behind" is now active!');
 
-	waitForGitExtension().then(git => {
-		log(`${git.repositories.length} repos found!`);
+	waitForGitExtension().then(gitExtension => {
+		if (gitExtension.enabled) {
+			onGitExtensionEnabled(gitExtension.getAPI(1))
+		}
 
-		const repos: RepositoryWatcher[] = [];
-
-		git.repositories.forEach(repository => {
-			log(`setup listener for ${repository.rootUri}...`);
-
-			// TODO: somehow dispose the watchers
-			repos.push(new RepositoryWatcher(repository));
-		});
+		gitExtension.onDidChangeEnablement(enabled => {
+			if (enabled) {
+				onGitExtensionEnabled(gitExtension.getAPI(1))
+			}
+		});		
 	});
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { GitExtension, API } from '../libs/git';
+import { GitExtension } from '../libs/git';
 import { log } from './log';
 
 export async function waitForGitExtension(
@@ -7,15 +7,14 @@ export async function waitForGitExtension(
     checkEveryMs = 1000,
     tries = 0,
     onError: () => void = () => {}
-): Promise<API> {
+): Promise<GitExtension> {
     log('Waiting for Git Extension to be ready...');
 
     try {
         const api = vscode
             .extensions
             .getExtension<GitExtension>('vscode.git')!
-            .exports
-            .getAPI(1);
+            .exports;
 
             log(`Git Extension is ready after ${tries} tries!`);
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -4,5 +4,5 @@ const output = vscode.window.createOutputChannel('Am I Behind');
 
 export function log (message: string) {
     output.appendLine(message);
-    console.log(message);
+    console.log(`[Am I Behind] ${message}`);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,7 @@
+import * as vscode from 'vscode';
+
+export function extractRepositoryName(rootUri: vscode.Uri) {
+    const parts = rootUri.path.split('/');
+
+    return parts[parts.length - 1];
+}


### PR DESCRIPTION
#2 describes, that the extension does not work reliably in certain situations that still need to be reproduced.

In this branch/PR the monitoring of the git events is getting adjusted a bit. I'll try a few different approaches that could make the extension behave more like the little indicator (the [`SyncStatusBar`](https://github.com/microsoft/vscode/blob/master/extensions/git/src/statusbar.ts#L50)).

## Todos

- [ ] Listen to repository `open` and `close` events, so we know when to dispose old `RepositoryWatchers` or setup new ones.
- [x] Rework the logging a little bit so it is clear, that this extension logged something to the console.
- [ ] Actually use the activation events of the `GitExtension`
  - [x] ... for waiting for the extension to be ready
  - [ ] ... for detecting that the extension is actually enabled